### PR TITLE
eliminate unbounded thread creation in EventBus.publishSync (prevents “can’t start new thread” under sustained AUTH)

### DIFF
--- a/app/event_bus.py
+++ b/app/event_bus.py
@@ -1,42 +1,62 @@
 import asyncio
 import logging
-from threading import Thread
-
+from threading import Thread, RLock
 
 class EventBus:
     def __init__(self):
-        # stores all event subscriptions
-        self.__events = {}
+        self.__events = {}          # event_name -> [handlers]
+        self.__loop = None          # single long-lived loop
+        self.__thread = None        # single long-lived thread
+        self.__lock = RLock()
 
     def subscribe(self, event_name, handler):
-        if event_name not in self.__events:
-            self.__events[event_name] = []
-        self.__events[event_name].append(handler)
+        with self.__lock:
+            self.__events.setdefault(event_name, []).append(handler)
 
     def unsubscribe(self, event_name, handler):
-        if event_name in self.__events and handler in self.__events[event_name]:
-            self.__events[event_name].remove(handler)
+        with self.__lock:
+            if event_name in self.__events and handler in self.__events[event_name]:
+                self.__events[event_name].remove(handler)
 
     def __background_loop(self, loop):
         asyncio.set_event_loop(loop)
         loop.run_forever()
 
+    def __ensure_loop(self):
+        if self.__loop is None or self.__loop.is_closed():
+            loop = asyncio.new_event_loop()
+            t = Thread(target=self.__background_loop, args=(loop,), daemon=True)
+            t.start()
+            self.__loop = loop
+            self.__thread = t
+
     def publishSync(self, event_name, *args) -> bool:
-        loop = asyncio.new_event_loop()
-        t = Thread(target=self.__background_loop, args=(loop,), daemon=True)
-        t.start()
-        task = asyncio.run_coroutine_threadsafe(self.publish(event_name, args), loop)
-        return task.result()
+        # Reuse the single loop/thread; do NOT create a new one per call.
+        self.__ensure_loop()
+        fut = asyncio.run_coroutine_threadsafe(
+            self.publish(event_name, *args),   # <-- expand args correctly
+            self.__loop
+        )
+        return fut.result()
 
     async def publish(self, event_name, *args) -> bool:
         result = False
-        if event_name in self.__events:
+        # snapshot handlers to avoid mutation during iteration
+        handlers = list(self.__events.get(event_name, []))
+        if handlers:
             logging.debug(f"Publishing event: {event_name}")
-            for handler in self.__events[event_name]:
+            for handler in handlers:
                 if asyncio.iscoroutinefunction(handler):
                     result = await handler(*args)
                 else:
                     result = handler(*args)
         return result
+
+    # (optional) call this on clean shutdown if you wire signals
+    def shutdown(self, timeout=1.0):
+        if self.__loop and self.__loop.is_running():
+            self.__loop.call_soon_threadsafe(self.__loop.stop)
+            if self.__thread:
+                self.__thread.join(timeout=timeout)
 
 event_bus_instance = EventBus()


### PR DESCRIPTION
**Summary**
This PR removes a thread leak in the SMTP relay’s event bus. Previously, every call to publishSync created a new asyncio event loop and a new OS thread that was never shut down. Under steady SMTP AUTH traffic this led to unbounded thread growth and eventual failures with RuntimeError: can't start new thread. The fix reuses a single background event loop/thread and passes arguments correctly to handlers.

**Testing**
I have tested it for 2 day, with approx 200 emails per day, monitoring the number of threads, which remains limited to 5 threads. 

