### PR TITLE
Feature/docker image version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,8 @@
 name: Build and Push Docker Image
 
 on:
-  push:
-    branches:
-      - main  # Set to the branch name you want to trigger the build
+  release:
+    types: [published]
 
 jobs:
   build-and-push:
@@ -27,7 +26,9 @@ jobs:
         context: .
         file: ./Dockerfile  # Path to your Dockerfile
         push: true
-        tags: ggpwnkthx/microsoft-graph-smtp-relay  # Replace with your Docker Hub username, repository, and tag
+        tags: |
+          ggpwnkthx/microsoft-graph-smtp-relay:latest
+          ggpwnkthx/microsoft-graph-smtp-relay:${{ github.event.release.tag_name }}
 
     - name: Sync README to Docker Hub
       uses: peter-evans/dockerhub-description@v2


### PR DESCRIPTION
Changed Github Workflow `main.yml` to release and tag versions using Github Release.
Tags should contain the version number (E.g. 0.0.1)

Fixes #21 