### PR TITLE
Support legacy CRAM-MD5 authentication

### DIFF
--- a/app/handlers/microsoft_graph.py
+++ b/app/handlers/microsoft_graph.py
@@ -1,8 +1,12 @@
 import asyncio
+from hashlib import md5
+import hmac
 import io
 import math
+import secrets
+import time
 from typing import Optional
-from aiosmtpd.smtp import SMTP, Session, Envelope
+from aiosmtpd.smtp import SMTP, Session, Envelope, AuthResult
 from email import policy
 from email.header import decode_header, make_header
 from email.message import Message
@@ -320,6 +324,26 @@ class MicrosoftGraphHandler():
                     error_details = await response.json()
                     logging.warning(f"Failed to delete email: {response.status} - {error_details}")
                     return False
+
+    async def auth_CRAM__MD5(self, server: SMTP, args):
+        smtp_user = os.environ.get("SMTP_AUTH_USER", "")
+        smtp_pass = os.environ.get("SMTP_AUTH_PASS", "")
+
+        timestamp = f"<{int(time.time())}.{secrets.token_hex(4)}@{server.hostname}>"
+        challenge = timestamp.encode('utf-8')
+
+        client = await server.challenge_auth(challenge, True)
+        response = client.decode('ascii')
+
+        parts = response.split(' ')
+        username = parts[0]
+        pass_hash = parts[1]
+
+        hash_value = hmac.new(smtp_pass.encode('ascii'), challenge, md5).hexdigest()
+        
+        if username == smtp_user and pass_hash == hash_value:
+            return AuthResult(success=True)
+        return AuthResult(success=False, handled=False, message="504 Authentication failed")
 
     async def handle_DATA(self, server: SMTP, session: Session, envelope: Envelope) -> str:
         """


### PR DESCRIPTION
Support CRAM-MD5 authentication to avoid sending password in plain-text.
Also to support legacy devices (with a bit more security) to authenticate against this relay

So even if its not using TLS more security is given with this.

BTW: The `test\client.py` script is already using it, once CRAM-MD5 is available in `aiosmptd` and does a proper challenge

```
2025-09-16 17:10:27,373 - WARNING - auth_required == True but auth_require_tls == False
2025-09-16 17:10:27,373 - INFO - Available AUTH mechanisms: CRAM-MD5 LOGIN(builtin) PLAIN(builtin)
2025-09-16 17:10:27,373 - INFO - Peer: ('127.0.0.1', 53872)
2025-09-16 17:10:27,373 - INFO - ('127.0.0.1', 53872) handling connection
2025-09-16 17:10:27,383 - INFO - ('127.0.0.1', 53872) EOF received
2025-09-16 17:10:27,383 - INFO - Started SMTP service on 127.0.0.1:50020
2025-09-16 17:10:27,385 - INFO - ('127.0.0.1', 53872) Connection lost during _handle_client()
2025-09-16 17:10:27,386 - INFO - ('127.0.0.1', 53872) connection lost
C:\Users\ole\AppData\Roaming\Python\Python310\site-packages\aiosmtpd\smtp.py:372: UserWarning: Requiring AUTH while not requiring TLS can lead to security vulnerabilities!
  warn("Requiring AUTH while not requiring TLS "
2025-09-16 17:10:32,656 - WARNING - auth_required == True but auth_require_tls == False
2025-09-16 17:10:32,656 - INFO - Available AUTH mechanisms: CRAM-MD5 LOGIN(builtin) PLAIN(builtin)
2025-09-16 17:10:32,656 - INFO - Peer: ('127.0.0.1', 53879)
2025-09-16 17:10:32,656 - INFO - ('127.0.0.1', 53879) handling connection
2025-09-16 17:10:32,661 - INFO - ('127.0.0.1', 53879) >> b'ehlo host.docker.internal'
2025-09-16 17:10:32,661 - INFO - ('127.0.0.1', 53879) >> b'AUTH CRAM-MD5'
2025-09-16 17:10:37,218 - WARNING - Session.login_data is deprecated and will be removed in version 2.0
2025-09-16 17:10:37,228 - INFO - ('127.0.0.1', 53879) >> b'mail FROM:<xxx@xxx.xx> size=326747'
2025-09-16 17:10:37,228 - INFO - ('127.0.0.1', 53879) sender: xxx@xxx.xx
2025-09-16 17:10:37,228 - INFO - ('127.0.0.1', 53879) >> b'rcpt TO:<xxx@xxx.xx>'
2025-09-16 17:10:37,230 - INFO - ('127.0.0.1', 53879) recip: xxx@xxx.xx
2025-09-16 17:10:37,231 - INFO - ('127.0.0.1', 53879) >> b'rcpt TO:<xxx@xxx.xx>'
2025-09-16 17:10:37,231 - INFO - ('127.0.0.1', 53879) recip: xxx@xxx.xx
2025-09-16 17:10:37,231 - INFO - ('127.0.0.1', 53879) >> b'rcpt TO:<>'
2025-09-16 17:10:37,232 - INFO - ('127.0.0.1', 53879) recip: <>
2025-09-16 17:10:37,232 - INFO - ('127.0.0.1', 53879) >> b'data'
2025-09-16 17:10:37,918 - INFO - Draft message created with ID: AAkALgAAAAAAHYQDEapmEc2byACqAC-EWg0ATlsO_p_xxxxxxxxxxxxxxxxxxxxx
2025-09-16 17:10:38,730 - INFO - Upload session created for 'image.jpg'.
2025-09-16 17:10:40,034 - INFO - Upload session created for 'doc.pdf'.
2025-09-16 17:10:40,953 - INFO - Email sent successfully with large attachment!
2025-09-16 17:10:41,190 - INFO - Email successfully deleted!
2025-09-16 17:10:41,190 - INFO - ('127.0.0.1', 53879) >> b'QUIT'
2025-09-16 17:10:41,190 - INFO - ('127.0.0.1', 53879) Connection lost during _handle_client()
2025-09-16 17:10:41,195 - INFO - ('127.0.0.1', 53879) connection lost
```