### PR TITLE
[Subscription] Allow "sender" event to overwrite Reply-To headers

### DIFF
--- a/MIDDLEWARE.md
+++ b/MIDDLEWARE.md
@@ -44,6 +44,28 @@ class Middleware:
         mail_message.replace_header('Subject', '[ReplaceSubject middleware] ' + subject)
 ```
 
+Another example to overwrite the `Reply-To` header
+
+```python
+from event_bus import event_bus_instance
+from handlers.microsoft_graph import MicrosoftGraphHandler
+
+class Middleware:
+    """
+    Middleware to overwrite the Reply-To Header
+    """
+    def __init__(self, msGraphHandler: MicrosoftGraphHandler):
+        self.app = msGraphHandler.app
+        event_bus_instance.subscribe('sender', self.overwrite_reply_to)
+
+    async def overwrite_reply_to(self, sender_mail: str | None, reply_to: list):
+        # Overwrite reply to address
+        reply_to.clear()
+        reply_to.append({"emailAddress": {"address": "some@email.tld"}})
+        
+        return True
+```
+
 ### Event subscriptions and EventBus
 
 Below class graph displays methods in the EventBus

--- a/app/handlers/microsoft_graph.py
+++ b/app/handlers/microsoft_graph.py
@@ -143,8 +143,7 @@ class MicrosoftGraphHandler():
         token_response = self.app.acquire_token_for_client(scopes=[".default"])
         self.access_token = token_response.get("access_token")
 
-    async def __create_draft(self, email_message, envelope):
-        await event_bus_instance.publish('sender', envelope.mail_from)
+    async def __create_draft(self, email_message, envelope: Envelope):
 
          # Extract body and attachments using helper method
         body_content, content_type, attachments = MicrosoftGraphHandler._extract_body_and_attachments(email_message)
@@ -179,7 +178,8 @@ class MicrosoftGraphHandler():
                 if part and part not in parsed_to_cc:
                     bcc_recipients.extend(
                         MicrosoftGraphHandler._extract_email_address(part))
-                    
+
+        await event_bus_instance.publish('sender', envelope.mail_from, reply_to)
         await event_bus_instance.publish('recipients', to_recipients, cc_recipients, bcc_recipients)
         
         # Requires Microsoft Graph permission "Mail.ReadWrite"


### PR DESCRIPTION
Provide an option to overwrite the Reply-To header using the "sender" event subscription.

Example is added into MIDDLEWARE.md 