### PR TITLE
Fix unicode characters mangled in 8bit-encoded HTML email bodies

### DIFF
--- a/app/handlers/microsoft_graph.py
+++ b/app/handlers/microsoft_graph.py
@@ -95,9 +95,12 @@ class MicrosoftGraphHandler():
         content_type = "text"
         if body is not None:
             if body.get_content_type() == 'text/html':
-                # get content from html body
-                body_content = body.get_content()
                 content_type = "html"
+                cte = (body.get("Content-Transfer-Encoding") or "").strip().lower()
+                if cte == "8bit":
+                    body_content = body.get_payload()
+                else:
+                    body_content = body.get_content()
             else:
                 # but get payload from plain text
                 pair = dict(body.items())


### PR DESCRIPTION
**Problem**
HTML emails from WooCommerce (and other senders) using 8bit Content-Transfer-Encoding were displaying characters like ' (right single quote) as the literal  text \u2019.

**Root cause**
The HTML body path always used get_content() to extract the body. Internally, get_content() calls get_payload(decode=True), which — when the payload is stored as a Python string (as it is when using the string-based Parser) — tries to encode non-ASCII characters as ASCII, falls back to raw_unicode_escape, and converts characters like ' (U+2019) into the literal 6-character sequence \u2019.

**Fix**
Added the same 8bit special case for HTML bodies that already existed for plain text bodies: use get_payload() directly, which returns the string as-is with Unicode characters intact.